### PR TITLE
edit typo from add members to add courses

### DIFF
--- a/pages/manual/planet.md
+++ b/pages/manual/planet.md
@@ -490,7 +490,7 @@ After clicking the `Add Members` button, you will be able to add members
 ![Add Members](images/planet-teams-members.png)
 
 #### 3. Manage Courses
-After clicking the `Add Members` button, you will be able to add and remove courses
+After clicking the `Add Courses` button, you will be able to add and remove courses
 
 ![Teams Courses](images/planet-teams-courses.png)
 


### PR DESCRIPTION
Under Teams/Manage Teams/Manage Courses, there is typo, the word inside back tick should be Add Courses instead of Add Members. Thanks,