### PR TITLE
add phase under the action menu and move images

### DIFF
--- a/pages/manual/planet.md
+++ b/pages/manual/planet.md
@@ -153,11 +153,11 @@ The action menu has several different actions available.
 
 ![course-added](images/my-courses-added.png)
 
-Alternatively, click on your course on the courses list then click the "Join" button near the top-right of the course page.
+Alternatively, click on your course on the courses list to get the course page then click the "Join" button near the top-right of the course page.
 
 3. To leave a course, select the checkbox next to a course that you are already a part of then click the "Leave Selected" button. The selected course is no longer part of your myCourses, and can no longer be seen on the front page's dashboard. Multiple courses are able to be left at once.
 
-Alternatively, click on your course on the courses list then click the "Leave" button near the top-right of the course page.
+Alternatively, click on your course on the courses list to get the course page then click the "Leave" button near the top-right of the course page.
 
 4. To change a collection, select the checkbox next to a course then click "Change Collections". To learn what a collection is, click [here](#Course_Collections).
 
@@ -233,10 +233,13 @@ Upon clicking the "Add Question" button, you will find there are four types of q
 
 
 * Text - Simply fill out the question detail or query for this type of question. The test taker will automatically get a textbox for filling out his or her answer.  
-	* Short answer: Usually single line short answers.  
-	* Long answer: More possibly to be very long descriptive answers.	
+
+	* Short answer: Usually single line short answers. 
 
 ![Short answer](images/courses-test-short.png)
+
+	* Long answer: More possibly to be very long descriptive answers.	
+  
 ![Long answer](images/courses-test-long.png)
 
 

--- a/pages/manual/planet.md
+++ b/pages/manual/planet.md
@@ -233,13 +233,10 @@ Upon clicking the "Add Question" button, you will find there are four types of q
 
 
 * Text - Simply fill out the question detail or query for this type of question. The test taker will automatically get a textbox for filling out his or her answer.  
-
-	* Short answer: Usually single line short answers. 
-
-![Short answer](images/courses-test-short.png)
-
+	* Short answer: Usually single line short answers.  
 	* Long answer: More possibly to be very long descriptive answers.	
 
+![Short answer](images/courses-test-short.png)
 ![Long answer](images/courses-test-long.png)
 
 
@@ -273,22 +270,18 @@ Upon clicking the "Add Question" button, you will find there are four types of q
 
 
 * Text - Simply fill out the question detail or query for this type of question. The survey taker will automatically get a textbox for filling out his or her answer.  
-	* Short answer: Usually single line short answers. 
-
-![Short answer](images/courses-test-short.png)
-
+	* Short answer: Usually single line short answers.  
 	* Long answer: More possibly to be very long descriptive answers.  
 
+![Short answer](images/courses-test-short.png)
 ![Long answer](images/courses-test-long.png)
 
 
 * Multiple Choice - Click the "Add Choice" button to create a choice of answers for the question. Click the red circle button to the right of the choice to delete it from the question. __Unlike tests, there are no checkboxes denoting the "correct" choice, as this is a survey.__  
 	* Single answer  
-
-![Multiple choice single answer](images/courses-survey-mc-single.png)
-
 	* Multiple answer  
 	
+![Multiple choice single answer](images/courses-survey-mc-single.png)
 ![Multiple choice multiple answer](images/courses-survey-mc-multiple.png)
 
 Fill out the appropriate fields on however many questions you want for this survey. When you are finished, press the "Preview Survey" button to preview how your survey will look, then press the "Save" button to save the entire survey.

--- a/pages/manual/planet.md
+++ b/pages/manual/planet.md
@@ -239,7 +239,7 @@ Upon clicking the "Add Question" button, you will find there are four types of q
 ![Short answer](images/courses-test-short.png)
 
 	* Long answer: More possibly to be very long descriptive answers.	
-  
+
 ![Long answer](images/courses-test-long.png)
 
 
@@ -273,18 +273,22 @@ Upon clicking the "Add Question" button, you will find there are four types of q
 
 
 * Text - Simply fill out the question detail or query for this type of question. The survey taker will automatically get a textbox for filling out his or her answer.  
-	* Short answer: Usually single line short answers.  
-	* Long answer: More possibly to be very long descriptive answers.  
+	* Short answer: Usually single line short answers. 
 
 ![Short answer](images/courses-test-short.png)
+
+	* Long answer: More possibly to be very long descriptive answers.  
+
 ![Long answer](images/courses-test-long.png)
 
 
 * Multiple Choice - Click the "Add Choice" button to create a choice of answers for the question. Click the red circle button to the right of the choice to delete it from the question. __Unlike tests, there are no checkboxes denoting the "correct" choice, as this is a survey.__  
 	* Single answer  
+
+![Multiple choice single answer](images/courses-survey-mc-single.png)
+
 	* Multiple answer  
 	
-![Multiple choice single answer](images/courses-survey-mc-single.png)
 ![Multiple choice multiple answer](images/courses-survey-mc-multiple.png)
 
 Fill out the appropriate fields on however many questions you want for this survey. When you are finished, press the "Preview Survey" button to preview how your survey will look, then press the "Save" button to save the entire survey.


### PR DESCRIPTION
add phase "to get the course page" in two sentences to have users understand better and move images just below the sentence that explains the image.