### PR TITLE
remove references to myMeetups

### DIFF
--- a/pages/manual/planet.md
+++ b/pages/manual/planet.md
@@ -524,39 +524,6 @@ After clicking the `Add Courses` button, you will be able to add and remove cour
 #### 4. Accept / Reject
 Here, you will be able to accept or reject any members who requested to join the team
 
-## Meetups
-Meetups is where you can coordinate meetups by creating them, joining them and more!
-
-### Navigating To The Meetup Page
-As you can see below, once you are in your planet dashboard you can access the page using the **Dashboard Tile** (Red box) and the **Menu** (Blue box):
-
-![Access Meetup](images/planet-access-meetup.png)
-
-### Available Actions On Meetup Page
-1. Traversing the page. Here you can **filter and search** (Red box) for specific meetups and use the 
-**page navigation** (Blue box) to traverse the list of meetings and show the number of them on the page.
-You can also click on the plus icon (Green box) to add a new meetup (see "Adding meetups")
-
-![Access Meetup](images/planet-meetup-page.png)
-
-2. You can join meetups (Picture 1) and leave meetups you are apart of (Picture 2). First click on the small box on the left of the meetup to select it and pick an action (Red box).
-
-![Leave Meetup](images/planet-join-meetup.png)
-![Join Meetup](images/planet-leave-meetup.png)
-
-### Adding Meetups
-After clicking on the plus icon, you will have come to this page. Here you will need to add a **Title and a Description** (Blue box). Next you will have to pick the **duration of the meetup**, category, and location** (Red box).
-
-**Note:** If you pick the frequency to be weekly, you will be prompted to choose which days of the week the meetup will occur (as shown below).
-
-![Join Meetup](images/planet-create-meetup.png)
-
-
-### Inviting Others
-Once you navigate into a meetup, you will be able to invite other members by clicking the `Invite Member` button (Red box).
-
-![Invite Others To Meetup](images/planet-meetup-invite.png)
-
 ## News
 News is where you can view any posts made by any users.
 
@@ -632,10 +599,6 @@ As you can see below, once you are in your planet dashboard you can add feedback
 3. Teams
 
     ![Teams Feedback](images/planet-feedback-teams.png)
-
-4. Meetups
-
-    ![Meetups Feedback](images/planet-feedback-meetups.png)
 
 ### View Feedbacks
 Firstly, you can view your feedbacks by going to the `Manager Page` (Picture 1) then `Feedbacks` (Picture 2) to view the feedback list.


### PR DESCRIPTION
It appears that 'myMeetups' has been replaced by 'myLife'.  This PR simply removes references to myMeetups.  I can also prepare an additional PR to summarize the 'myLife' section if you think this would be useful.